### PR TITLE
feat: support Ubuntu 26.04 LTS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     id: system
     attributes:
       label: System
-      placeholder: "Blade 18 2023 · Fedora 44 or Ubuntu 24.04 · GNOME Wayland · SELinux enforcing"
+      placeholder: "Blade 18 2023 · Fedora 44 or Ubuntu 26.04 · GNOME Wayland · SELinux enforcing"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu:22.04, ubuntu:24.04, debian:12, debian:13]
+        image: [ubuntu:22.04, ubuntu:24.04, ubuntu:26.04, debian:12, debian:13]
     container:
       image: ${{ matrix.image }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu:22.04, ubuntu:24.04, debian:12, debian:13]
+        image: [ubuntu:22.04, ubuntu:24.04, ubuntu:26.04, debian:12, debian:13]
     container:
       image: ${{ matrix.image }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Fang are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 [Semantic Versioning](https://semver.org/).
 
+## [0.9.6] — 2026-07-30 — Ubuntu 26.04 LTS
+
+### Added
+
+- Ubuntu 26.04 LTS is a supported installation base, both as a direct match and
+  through the compatible-family path used by derivatives such as Zorin OS, Linux
+  Mint, Pop!_OS, and KDE neon.
+- Clean-container package lifecycle checks now run on Ubuntu 26.04 before any
+  release can be published.
+
+### Fixed
+
+- The from-source build script now reports that it supports Debian and Ubuntu
+  only, and points at the RPM packages, instead of failing with a missing
+  `apt-get` after asking for administrator access.
+
 ## [0.9.5] — 2026-07-23 — Neon Fang installer
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,8 @@ All notable changes to Fang are documented here. The format is based on
 - Privileged `fangd` daemon + unprivileged Tauri/Svelte app over a Unix socket;
   settings persist and re-apply after reboot and suspend/resume.
 
+[0.9.6]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.6
+[0.9.5]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.5
 [0.9.4]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.4
 [0.9.3]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.3
 [0.9.2]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "fang-protocol"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "fangd"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "env_logger",
  "fang-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/fang-protocol", "crates/fangd"]
 exclude = ["app/src-tauri"]
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 license = "GPL-2.0"
 repository = "https://github.com/bladeandsoulx/fang-razer-linux"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ its own safe fan limits and feature list.
 
 Tested x86_64 Linux bases:
 
-- Ubuntu 22.04 and 24.04
+- Ubuntu 22.04, 24.04, and 26.04
 - Debian 12 and 13
 - Fedora 43 and 44
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ bash install.sh
 This lets you read the script before it asks for administrator access.
 
 For an extra integrity check, download the installer and checksum manifest from
-the pinned v0.9.5 release:
+the pinned v0.9.6 release:
 
 ```bash
-curl -fLO 'https://github.com/bladeandsoulx/fang-razer-linux/releases/download/v0.9.5/{install.sh,SHA256SUMS}'
+curl -fLO 'https://github.com/bladeandsoulx/fang-razer-linux/releases/download/v0.9.6/{install.sh,SHA256SUMS}'
 grep '  install.sh$' SHA256SUMS > install.sh.sha256
 sha256sum --check install.sh.sha256
 ```
@@ -128,10 +128,10 @@ Download both packages from the same release, then install them together:
 
 ```bash
 # Ubuntu or Debian
-sudo apt install ./fangd_0.9.5-1_amd64.deb ./Fang_0.9.5_amd64.deb
+sudo apt install ./fangd_0.9.6-1_amd64.deb ./Fang_0.9.6_amd64.deb
 
 # Fedora 43 or 44
-sudo dnf install ./fangd-0.9.5-1.x86_64.rpm ./fang-0.9.5-1.x86_64.rpm
+sudo dnf install ./fangd-0.9.6-1.x86_64.rpm ./fang-0.9.6-1.x86_64.rpm
 ```
 
 Enable the background service and give your user access:

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fang-ui",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fang-ui",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fang-ui",
   "private": true,
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "fang"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "env_logger",
  "fang-protocol",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "fang-protocol"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fang"
 description = "Fang — Synapse-style control center for Razer Blade laptops on Linux"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 license = "GPL-2.0"
 repository = "https://github.com/bladeandsoulx/fang-razer-linux"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fang",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "dev.fang.app",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -63,7 +63,7 @@
     "linux": {
       "deb": {
         "depends": [
-          "fangd (>= 0.9.5)",
+          "fangd (>= 0.9.6)",
           "fangd (<< 0.10.0)"
         ]
       }

--- a/app/src/lib/changelog-content.test.js
+++ b/app/src/lib/changelog-content.test.js
@@ -9,15 +9,35 @@ const panel = fs.readFileSync(path.join(root, 'app/src/screens/Changelog.svelte'
 const changelog = fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8');
 
 test('the in-app changelog contains the latest releases in descending order', () => {
+  const v096 = panel.indexOf("version: '0.9.6'");
   const v095 = panel.indexOf("version: '0.9.5'");
   const v094 = panel.indexOf("version: '0.9.4'");
   const v093 = panel.indexOf("version: '0.9.3'");
   const v092 = panel.indexOf("version: '0.9.2'");
 
-  assert.ok(v095 >= 0, 'v0.9.5 must be present');
+  assert.ok(v096 >= 0, 'v0.9.6 must be present');
+  assert.ok(v095 > v096, 'v0.9.5 must follow v0.9.6');
   assert.ok(v094 > v095, 'v0.9.4 must follow v0.9.5');
   assert.ok(v093 > v094, 'v0.9.3 must follow v0.9.4');
   assert.ok(v092 > v093, 'v0.9.2 must follow v0.9.3');
+});
+
+test('v0.9.6 records the Ubuntu 26.04 release', () => {
+  const v096Start = panel.indexOf("version: '0.9.6'");
+  const v095Start = panel.indexOf("version: '0.9.5'");
+  const v096Panel = panel.slice(v096Start, v095Start);
+  const v096Changelog = changelog.slice(
+    changelog.indexOf('## [0.9.6]'),
+    changelog.indexOf('## [0.9.5]')
+  );
+
+  assert.ok(v096Start >= 0, 'v0.9.6 must be present');
+  assert.ok(v095Start > v096Start, 'v0.9.5 must follow v0.9.6');
+  assert.match(v096Panel, /Ubuntu 26\.04 LTS is a supported installation base/i);
+  assert.match(v096Panel, /Debian and Ubuntu only/i);
+  assert.match(v096Changelog, /## \[0\.9\.6\].*Ubuntu 26\.04 LTS/);
+  assert.match(v096Changelog, /compatible-family path/i);
+  assert.match(v096Changelog, /apt-get/);
 });
 
 test('v0.9.5 records the focused Neon Fang release', () => {

--- a/app/src/screens/Changelog.svelte
+++ b/app/src/screens/Changelog.svelte
@@ -2,6 +2,25 @@
   // Mirrors CHANGELOG.md, condensed for the panel. Newest first.
   const RELEASES = [
     {
+      version: '0.9.6',
+      date: '2026-07-30',
+      title: 'Ubuntu 26.04 LTS',
+      groups: [
+        {
+          kind: 'Added',
+          items: [
+            'Ubuntu 26.04 LTS is a supported installation base, directly and through compatible-family derivatives.'
+          ]
+        },
+        {
+          kind: 'Fixed',
+          items: [
+            'The from-source build script now explains that it supports Debian and Ubuntu only, instead of failing part way through on other distributions.'
+          ]
+        }
+      ]
+    },
+    {
       version: '0.9.5',
       date: '2026-07-23',
       title: 'Neon Fang installer',

--- a/docs/superpowers/plans/2026-07-30-ubuntu-2604-support.md
+++ b/docs/superpowers/plans/2026-07-30-ubuntu-2604-support.md
@@ -1,0 +1,262 @@
+# Ubuntu 26.04 LTS Support Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept Ubuntu 26.04 LTS (`resolute`) as a supported installation base,
+validate the existing DEBs on it in CI, guard the Debian/Ubuntu-only source
+installer, and ship all of it as release v0.9.6.
+
+**Architecture:** `detect_platform()` in `install.sh` gains one direct entry
+(`26.04:resolute`) and one derivative entry (`resolute`), mirroring how `noble`
+is already handled in both tiers. The `deb-test` matrix in both workflows gains
+`ubuntu:26.04`, so the existing `packaging/deb/verify.sh` lifecycle check runs on
+the new base against the same artifacts. No package is rebuilt or re-specced.
+
+**Tech Stack:** Bash, Node 22 `node:test`, GitHub Actions, Ubuntu 26.04
+containers.
+
+## Global Constraints
+
+- Support Ubuntu 26.04 LTS on x86_64 only.
+- Keep the `VERSION_ID:VERSION_CODENAME` pairing in the direct detection tier.
+  Never match `VERSION_ID` alone.
+- Keep building DEBs on the `ubuntu-22.04` runner. That runner sets
+  `libc6 (>= 2.35)`, which is what keeps Ubuntu 22.04 and Debian 12 installable.
+- Do not modify the DEB or RPM specs, dependencies, or build scripts.
+- Do not modify daemon, EC, or protocol code. This release changes no hardware
+  behavior.
+- Preserve the executable mode bit on `packaging/install-from-source.sh`;
+  `release-contract.test.mjs` asserts it.
+- Ship as v0.9.6 with `app/scripts/version.mjs set` as the version authority.
+- Stop before tagging or pushing a release.
+
+## File Structure
+
+### Create
+
+- `docs/superpowers/specs/2026-07-30-ubuntu-2604-support-design.md` — approved design.
+- `docs/superpowers/plans/2026-07-30-ubuntu-2604-support.md` — this plan.
+
+### Modify
+
+- `install.sh` — direct and derivative detection entries for Ubuntu 26.04.
+- `packaging/installer/installer.test.mjs` — direct platform, derivative, and
+  mismatched-codename cases.
+- `.github/workflows/ci.yml` — `ubuntu:26.04` in the `deb-test` matrix.
+- `.github/workflows/release.yml` — `ubuntu:26.04` in the `deb-test` matrix.
+- `packaging/install-from-source.sh` — Debian/Ubuntu family guard.
+- `packaging/release/release-contract.test.mjs` — pinned-version assertions.
+- `app/src/screens/Changelog.svelte` — v0.9.6 in-app entry.
+- `app/src/lib/changelog-content.test.js` — v0.9.6 ordering assertion.
+- `README.md` — tested bases list, pinned-release block, manual-install commands.
+- `.github/ISSUE_TEMPLATE/bug_report.yml` — current system example.
+- `Cargo.toml`, `Cargo.lock`, `app/package.json`, `app/package-lock.json`,
+  `app/src-tauri/Cargo.toml`, `app/src-tauri/Cargo.lock`,
+  `app/src-tauri/tauri.conf.json`, `packaging/installer/banner.txt`, both RPM
+  specs, `CHANGELOG.md` — release v0.9.6 synchronization.
+
+---
+
+### Task 1: Widen the installer platform gate
+
+**Files:**
+- Modify: `packaging/installer/installer.test.mjs`
+- Modify: `install.sh`
+
+**Interfaces:**
+- Consumes: `/etc/os-release` `ID`, `VERSION_ID`, `VERSION_CODENAME`,
+  `ID_LIKE`, `UBUNTU_CODENAME`.
+- Produces: `PACKAGE_FAMILY=deb` and `PLATFORM_LABEL='Ubuntu 26.04'` for
+  `ID=ubuntu` with `26.04`/`resolute`, and for `resolute` derivatives with the
+  existing derivative warning.
+
+- [ ] **Step 1: Add the failing detection tests**
+
+In `packaging/installer/installer.test.mjs`, add to `directPlatforms`:
+
+```js
+['Ubuntu 26.04', 'ID=ubuntu\nVERSION_ID="26.04"\nVERSION_CODENAME=resolute\n', 'DEB'],
+```
+
+Add to `derivatives`:
+
+```js
+[
+  'zorin resolute',
+  'Ubuntu 26.04',
+  'ID=zorin\nID_LIKE="ubuntu debian"\nVERSION_ID="19"\nUBUNTU_CODENAME=resolute\n'
+],
+```
+
+Add a negative case asserting a 26.04 `VERSION_ID` with a wrong codename still
+fails, so the pairing cannot regress to a version-only match.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+node --test packaging/installer/installer.test.mjs
+```
+
+Expected: the three new cases fail with `Unsupported Ubuntu release: 26.04.`
+
+- [ ] **Step 3: Add the detection entries**
+
+In the direct `ubuntu)` case, after the `24.04:noble` arm:
+
+```bash
+26.04:resolute) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 26.04' ;;
+```
+
+In the derivative `OS_UBUNTU_CODENAME` case, after the `noble)` arm:
+
+```bash
+resolute) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 26.04' ;;
+```
+
+- [ ] **Step 4: Confirm the whole installer suite passes**
+
+```bash
+node --test packaging/installer/installer.test.mjs
+```
+
+Expected: PASS, including the pre-existing rejection and spoofing cases.
+
+---
+
+### Task 2: Validate the DEBs on Ubuntu 26.04 in CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: the `fang-debs` artifact built on `ubuntu-22.04`.
+- Produces: a `test DEBs (ubuntu:26.04)` job gating both CI and release.
+
+- [ ] **Step 1: Extend both matrices**
+
+Add `ubuntu:26.04` to the `deb-test` matrix `image` list in each workflow. Leave
+the `debs` build job on `ubuntu-22.04`.
+
+- [ ] **Step 2: Confirm no other job pins a base list**
+
+```bash
+grep -rn "ubuntu:2\|debian:1\|fedora:4" .github/workflows/
+```
+
+Expected: only the two `deb-test` matrices and the Fedora RPM jobs.
+
+---
+
+### Task 3: Guard the from-source installer
+
+**Files:**
+- Modify: `packaging/install-from-source.sh`
+
+**Interfaces:**
+- Consumes: `/etc/os-release` `ID` and `ID_LIKE`.
+- Produces: exit status 1 with an RPM-path pointer on non-Debian-family systems;
+  unchanged behavior on Debian and Ubuntu.
+
+- [ ] **Step 1: Add the family check**
+
+After the root check and before `apt-get update`, source-free-read
+`/etc/os-release` and exit unless `ID` or `ID_LIKE` names `ubuntu` or `debian`.
+Keep it minimal — no codename pinning, no family-conflict logic.
+
+- [ ] **Step 2: Verify the guard both ways**
+
+Run the script with a stubbed non-Debian `os-release` and confirm it exits before
+any `apt-get` call, then confirm the real host still passes the check.
+
+- [ ] **Step 3: Confirm the mode bit survived**
+
+```bash
+node --test packaging/release/release-contract.test.mjs
+```
+
+---
+
+### Task 4: Synchronize release v0.9.6
+
+**Files:**
+- Modify: `CHANGELOG.md`, `app/src/screens/Changelog.svelte`,
+  `app/src/lib/changelog-content.test.js`,
+  `packaging/release/release-contract.test.mjs`, `README.md`, plus every file
+  owned by `version.mjs`.
+
+- [ ] **Step 1: Bump the version**
+
+```bash
+node app/scripts/version.mjs set 0.9.6
+```
+
+- [ ] **Step 2: Write the changelog entry**
+
+Add `## [0.9.6] — 2026-07-30 — Ubuntu 26.04 LTS` to `CHANGELOG.md`.
+`version.mjs check` asserts this header matches the bumped version.
+
+- [ ] **Step 3: Update the in-app changelog and its test**
+
+Add the `version: '0.9.6'` entry to `Changelog.svelte` and extend the
+descending-order assertions in `changelog-content.test.js`.
+
+- [ ] **Step 4: Update pinned-version assertions and README examples**
+
+Update the three hard-coded `v0.9.5` assertions in
+`release-contract.test.mjs` and the matching README pinned-release and
+manual-install blocks.
+
+- [ ] **Step 5: Verify version synchronization**
+
+```bash
+node app/scripts/version.mjs check
+```
+
+---
+
+### Task 5: Document the widened support list
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+
+- [ ] **Step 1: Add Ubuntu 26.04 to the tested bases list**
+
+Leave the derivative paragraph unchanged; it remains accurate.
+
+- [ ] **Step 2: Refresh the bug report placeholder**
+
+- [ ] **Step 3: Run the full local suite**
+
+```bash
+node app/scripts/version.mjs check
+node --test packaging/installer/installer.test.mjs
+node --test packaging/release/release-contract.test.mjs \
+            app/src/lib/changelog-content.test.js \
+            app/scripts/version.test.mjs
+cargo test --workspace
+```
+
+---
+
+### Task 6: Validate on a real Ubuntu 26.04 userland
+
+- [ ] **Step 1: Run the CI lifecycle check in a container**
+
+With DEBs staged in `target/deb-dist`:
+
+```bash
+podman run --rm -v "$PWD:/w" -w /w ubuntu:26.04 bash -c \
+  'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+     git ca-certificates systemd python3 desktop-file-utils procps && \
+   packaging/deb/verify.sh target/deb-dist'
+```
+
+Expected: both packages install, `fangd --version` matches, the unit verifies,
+the mock smoke test passes, and `ldd /usr/bin/fang` reports no missing objects.
+
+- [ ] **Step 2: Report which validation actually ran**
+
+State plainly whether the container check ran against freshly built v0.9.6 DEBs,
+against older staged DEBs, or was deferred to CI.

--- a/docs/superpowers/specs/2026-07-30-ubuntu-2604-support-design.md
+++ b/docs/superpowers/specs/2026-07-30-ubuntu-2604-support-design.md
@@ -1,0 +1,103 @@
+# Ubuntu 26.04 LTS support for Fang
+
+**Date:** 2026-07-30
+**Status:** Approved
+
+## Goal
+
+Accept Ubuntu 26.04 LTS ("Resolute Raccoon") as a supported installation base and
+ship that acceptance to users as release v0.9.6.
+
+Ubuntu 26.04 LTS released on 2026-04-23. Fang's installer gates on an explicit
+list of supported bases, and its newest Ubuntu entry is 24.04, so a user on the
+current LTS running the documented one-command install is rejected with
+`Unsupported Ubuntu release: 26.04.` before any download happens. The same
+rejection reaches Zorin, Linux Mint, and Pop!_OS users as those derivatives
+rebase onto `resolute`.
+
+## Scope
+
+### In scope
+
+- Ubuntu 26.04 LTS on x86_64, both as a direct `ID=ubuntu` match and via the
+  `ID_LIKE`/`UBUNTU_CODENAME` derivative path.
+- Clean-container DEB lifecycle validation on Ubuntu 26.04 in CI and release
+  gating.
+- A distribution guard for the Debian/Ubuntu-only from-source installer.
+- Release v0.9.6 synchronization and documentation of the widened support list.
+
+### Out of scope
+
+- Arch, Manjaro, and other pacman distributions. These require a third package
+  family and a restructured release asset contract.
+- openSUSE and other zypper distributions.
+- Ubuntu 25.10 or any non-LTS Ubuntu. Fang tracks Ubuntu LTS and Debian stable.
+- Retiring Ubuntu 22.04. It is supported until April 2027 and sets the glibc
+  floor for every released DEB.
+- New package builds. The existing amd64 DEBs are the artifacts that ship.
+- Real-hardware, enforcing-SELinux, or desktop-session validation from
+  container-only CI.
+
+## Compatibility evidence
+
+No packaging change is required. Verified against the `resolute` archive before
+committing to this design:
+
+| Requirement | Status in Ubuntu 26.04 |
+|---|---|
+| `libwebkit2gtk-4.1-0` (desktop DEB dependency) | Present, 2.52.3-0ubuntu0.26.04.2 |
+| `libayatana-appindicator3-1` (tray dependency) | Present, 0.5.94-1build1 |
+| `libgtk-3-0` (desktop DEB dependency) | Present |
+| `ubuntu:26.04` container image | Published on Docker Hub, amd64 |
+
+The desktop DEB's hard dependency on WebKitGTK 4.1 was the one real risk: had
+26.04 dropped the 4.1 soname in favour of a GTK4-era WebKitGTK, this change
+would have required a Tauri-level migration rather than a gate widening. It did
+not.
+
+Both DEBs are built on the `ubuntu-22.04` GitHub runner, producing
+`libc6 (>= 2.35)`. That floor installs cleanly on 26.04's newer glibc, so the
+same artifacts serve all four Debian-family bases. The build runner must not be
+raised; doing so would silently drop Ubuntu 22.04 and Debian 12.
+
+## Detection design
+
+`detect_platform()` in `install.sh` keeps its existing two-tier shape.
+
+The direct tier matches `VERSION_ID` and `VERSION_CODENAME` as a pair
+(`26.04:resolute`). This pairing is deliberate: it means a partially forged or
+truncated `os-release` fails closed instead of selecting a package family. The
+new entry preserves that property rather than matching `VERSION_ID` alone.
+
+The derivative tier maps `UBUNTU_CODENAME=resolute` to the Ubuntu 26.04 label
+and emits the existing `DERIVATIVE_WARNING`, so a rebased Zorin or Mint install
+resolves to the correct DEBs while still being told it is not release-tested
+directly.
+
+No change is made to the family-conflict check, the architecture check, or the
+checksum and metadata verification that follow detection.
+
+## From-source installer guard
+
+`packaging/install-from-source.sh` is documented as Debian/Ubuntu-only in both
+`README.md` and `HARDWARE_TESTING.md`, and it calls `apt-get` unconditionally. A
+Fedora user who runs it anyway currently sees a bare `apt-get: command not
+found` after having already been prompted for root.
+
+The script gains an early `os-release` family check that exits non-zero with a
+message pointing at the RPM installation path. It stays intentionally simpler
+than `install.sh`: it needs no codename pinning, no family-conflict handling, and
+no architecture check, because it builds from source on the machine it runs on.
+
+## Release design
+
+The installer is release-locked: `install.sh` carries `readonly VERSION` and
+`readonly RELEASE_TAG`, and users fetch it from `releases/latest/download`. A
+widened gate therefore reaches nobody until a new tag exists. Ubuntu 26.04
+support ships as patch release v0.9.6, following the precedent of v0.9.3, which
+shipped Fedora support the same way.
+
+`app/scripts/version.mjs set` remains the single source of version truth and
+synchronizes every packaged component. Files it does not own — the changelog
+prose, the in-app changelog panel, and the README's pinned-release examples —
+are updated by hand and guarded by existing tests.

--- a/install.sh
+++ b/install.sh
@@ -600,8 +600,8 @@ mutate_system() {
 main() {
 set -euo pipefail
 umask 077
-readonly VERSION='0.9.5'
-readonly RELEASE_TAG='v0.9.5'
+readonly VERSION='0.9.6'
+readonly RELEASE_TAG='v0.9.6'
 readonly REPOSITORY='bladeandsoulx/fang-razer-linux'
 readonly RELEASE_BASE="https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}"
 readonly DEB_FANG="Fang_${VERSION}_amd64.deb"

--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,7 @@ detect_platform() {
       case $OS_VERSION_ID:$OS_VERSION_CODENAME in
         22.04:jammy) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 22.04' ;;
         24.04:noble) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 24.04' ;;
+        26.04:resolute) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 26.04' ;;
         *) fatal "Unsupported Ubuntu release: ${OS_VERSION_ID:-unknown}." ;;
       esac
       return
@@ -240,6 +241,7 @@ detect_platform() {
     case $OS_UBUNTU_CODENAME in
       jammy) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 22.04' ;;
       noble) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 24.04' ;;
+      resolute) PACKAGE_FAMILY=deb; PLATFORM_LABEL='Ubuntu 26.04' ;;
       *) fatal "Unsupported or missing Ubuntu base for $OS_ID." ;;
     esac
   elif ((debian_like)); then

--- a/packaging/deb/verify.test.mjs
+++ b/packaging/deb/verify.test.mjs
@@ -38,8 +38,8 @@ test('DEB verifier covers install, runtime, integrity, and removal lifecycle', (
   assert.match(source, /packaged file remains after removal/);
 });
 
-test('CI and release test one DEB pair on all four supported bases', () => {
-  const images = ['ubuntu:22.04', 'ubuntu:24.04', 'debian:12', 'debian:13'];
+test('CI and release test one DEB pair on all five supported bases', () => {
+  const images = ['ubuntu:22.04', 'ubuntu:24.04', 'ubuntu:26.04', 'debian:12', 'debian:13'];
   for (const workflow of workflows) {
     const source = fs.readFileSync(workflow, 'utf8');
     for (const image of images) assert.match(source, new RegExp(image.replace('.', '\\.')));

--- a/packaging/install-from-source.sh
+++ b/packaging/install-from-source.sh
@@ -3,27 +3,141 @@
 # Usage: sudo ./packaging/install-from-source.sh   (run from the repo root)
 set -euo pipefail
 
+source_installer_decode_os_value() {
+    local raw=$1
+    local destination=$2
+    local decoded=
+    local inner
+    local char
+    local next
+    local index
+
+    if [[ ${raw:0:1} == '"' ]]; then
+        [[ ${#raw} -ge 2 && ${raw: -1} == '"' ]] || return 1
+        inner=${raw:1:${#raw}-2}
+        index=0
+        while ((index < ${#inner})); do
+            char=${inner:index:1}
+            if [[ $char == \\ ]]; then
+                ((index += 1))
+                ((index < ${#inner})) || return 1
+                next=${inner:index:1}
+                case $next in
+                    '$'|'`'|'"'|\\) decoded+=$next ;;
+                    *) return 1 ;;
+                esac
+            else
+                decoded+=$char
+            fi
+            ((index += 1))
+        done
+    elif [[ ${raw:0:1} == "'" ]]; then
+        [[ ${#raw} -ge 2 && ${raw: -1} == "'" ]] || return 1
+        inner=${raw:1:${#raw}-2}
+        [[ $inner != *"'"* ]] || return 1
+        decoded=$inner
+    else
+        decoded=$raw
+    fi
+    printf -v "$destination" '%s' "$decoded"
+}
+
+source_installer_valid_os_value() {
+    local key=$1
+    local value=$2
+    case $key in
+        ID) [[ $value =~ ^[a-z0-9._+-]+$ ]] ;;
+        ID_LIKE) [[ $value =~ ^[a-z0-9._+-]+([[:space:]]+[a-z0-9._+-]+)*$ ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+source_installer_read_os_release() {
+    local source=$1
+    local line
+    local key
+    local raw
+    local value
+    declare -A seen=()
+
+    DISTRO_ID=
+    DISTRO_ID_LIKE=
+
+    if [[ ! -r $source ]]; then
+        echo "cannot read operating-system identity from $source" >&2
+        return 1
+    fi
+    while IFS= read -r line || [[ -n $line ]]; do
+        [[ -z $line || $line == \#* ]] && continue
+        if [[ $line != *=* ]]; then
+            echo "malformed os-release line: $line" >&2
+            return 1
+        fi
+        key=${line%%=*}
+        raw=${line#*=}
+        case $key in
+            ID|ID_LIKE) ;;
+            *) continue ;;
+        esac
+        if [[ -n ${seen[$key]+present} ]]; then
+            echo "duplicate os-release field: $key" >&2
+            return 1
+        fi
+        seen[$key]=1
+        value=
+        if ! source_installer_decode_os_value "$raw" value; then
+            echo "malformed os-release value for $key" >&2
+            return 1
+        fi
+        if ! source_installer_valid_os_value "$key" "$value"; then
+            echo "invalid os-release value for $key" >&2
+            return 1
+        fi
+        case $key in
+            ID) DISTRO_ID=$value ;;
+            ID_LIKE) DISTRO_ID_LIKE=$value ;;
+        esac
+    done < "$source"
+    if [[ -z $DISTRO_ID ]]; then
+        echo "operating-system ID is missing" >&2
+        return 1
+    fi
+}
+
+source_installer_id_like_has() {
+    local wanted=$1
+    local item
+    for item in $DISTRO_ID_LIKE; do
+        [[ $item == "$wanted" ]] && return 0
+    done
+    return 1
+}
+
+source_installer_require_debian_family() {
+    local source=${1:-/etc/os-release}
+
+    source_installer_read_os_release "$source" || return 1
+    if [[ $DISTRO_ID == debian || $DISTRO_ID == ubuntu ]] ||
+        source_installer_id_like_has debian ||
+        source_installer_id_like_has ubuntu; then
+        return 0
+    fi
+
+    echo "this script builds from source on Debian and Ubuntu only" >&2
+    echo "detected: $DISTRO_ID" >&2
+    echo "on Fedora, install the released RPMs instead - see README.md" >&2
+    return 1
+}
+
+if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
+    return 0
+fi
+
 # Everything below assumes apt-get and Debian's -dev package names. Check the
 # family before asking for root, so a Fedora user gets a useful message instead
 # of a bare "apt-get: command not found" after already elevating.
 # Read os-release rather than sourcing it, matching install.sh's posture.
-if [ -r /etc/os-release ]; then
-    DISTRO_ID="$(sed -n 's/^ID=//p' /etc/os-release | tr -d '"' | head -n 1)"
-    DISTRO_ID_LIKE="$(sed -n 's/^ID_LIKE=//p' /etc/os-release | tr -d '"' | head -n 1)"
-else
-    DISTRO_ID=
-    DISTRO_ID_LIKE=
-fi
-
-case " $DISTRO_ID $DISTRO_ID_LIKE " in
-    *" debian "* | *" ubuntu "*) ;;
-    *)
-        echo "this script builds from source on Debian and Ubuntu only" >&2
-        echo "detected: ${DISTRO_ID:-unknown}" >&2
-        echo "on Fedora, install the released RPMs instead - see README.md" >&2
-        exit 1
-        ;;
-esac
+source_installer_require_debian_family /etc/os-release || exit 1
 
 if [ "$(id -u)" -ne 0 ]; then
     echo "run as root: sudo $0" >&2

--- a/packaging/install-from-source.sh
+++ b/packaging/install-from-source.sh
@@ -3,6 +3,28 @@
 # Usage: sudo ./packaging/install-from-source.sh   (run from the repo root)
 set -euo pipefail
 
+# Everything below assumes apt-get and Debian's -dev package names. Check the
+# family before asking for root, so a Fedora user gets a useful message instead
+# of a bare "apt-get: command not found" after already elevating.
+# Read os-release rather than sourcing it, matching install.sh's posture.
+if [ -r /etc/os-release ]; then
+    DISTRO_ID="$(sed -n 's/^ID=//p' /etc/os-release | tr -d '"' | head -n 1)"
+    DISTRO_ID_LIKE="$(sed -n 's/^ID_LIKE=//p' /etc/os-release | tr -d '"' | head -n 1)"
+else
+    DISTRO_ID=
+    DISTRO_ID_LIKE=
+fi
+
+case " $DISTRO_ID $DISTRO_ID_LIKE " in
+    *" debian "* | *" ubuntu "*) ;;
+    *)
+        echo "this script builds from source on Debian and Ubuntu only" >&2
+        echo "detected: ${DISTRO_ID:-unknown}" >&2
+        echo "on Fedora, install the released RPMs instead - see README.md" >&2
+        exit 1
+        ;;
+esac
+
 if [ "$(id -u)" -ne 0 ]; then
     echo "run as root: sudo $0" >&2
     exit 1

--- a/packaging/installer/banner.txt
+++ b/packaging/installer/banner.txt
@@ -7,4 +7,4 @@
 
     ━━━ RAZER BLADE CONTROL // INSTALLER ━━━━━━━━━━━
         FANS  ◆  POWER  ◆  LIGHTING  ◆  TELEMETRY
-        VERIFIED RELEASE  ·  v0.9.5  ·  x86_64
+        VERIFIED RELEASE  ·  v0.9.6  ·  x86_64

--- a/packaging/installer/installer.test.mjs
+++ b/packaging/installer/installer.test.mjs
@@ -294,6 +294,7 @@ esac
 const directPlatforms = [
   ['Ubuntu 22.04', 'ID=ubuntu\nVERSION_ID="22.04"\nVERSION_CODENAME=jammy\n', 'DEB'],
   ['Ubuntu 24.04', 'ID=ubuntu\nVERSION_ID="24.04"\nVERSION_CODENAME=noble\n', 'DEB'],
+  ['Ubuntu 26.04', 'ID=ubuntu\nVERSION_ID="26.04"\nVERSION_CODENAME=resolute\n', 'DEB'],
   ['Debian 12', 'ID=debian\nVERSION_ID="12"\nVERSION_CODENAME=bookworm\n', 'DEB'],
   ['Debian 13', 'ID=debian\nVERSION_ID="13"\nVERSION_CODENAME=trixie\n', 'DEB'],
   ['Fedora 43', 'ID=fedora\nVERSION_ID="43"\nPLATFORM_ID="platform:f43"\n', 'RPM'],
@@ -328,6 +329,11 @@ const derivatives = [
     'pop',
     'Ubuntu 24.04',
     'ID=pop\nID_LIKE="ubuntu debian"\nVERSION_ID="24.04"\nUBUNTU_CODENAME=noble\n'
+  ],
+  [
+    'neon',
+    'Ubuntu 26.04',
+    'ID=neon\nID_LIKE="ubuntu debian"\nVERSION_ID="26.04"\nUBUNTU_CODENAME=resolute\n'
   ],
   [
     'devuan',
@@ -380,6 +386,7 @@ test('refuses malformed, duplicate, unsupported, and conflicting platform data',
     'ID=ubuntu\nID=debian\nVERSION_ID="24.04"\n',
     'ID="$(touch /tmp/no)"\nVERSION_ID="24.04"\n',
     'ID=ubuntu\nVERSION_ID="26.04"\nVERSION_CODENAME=questing\n',
+    'ID=ubuntu\nVERSION_ID="26.04"\n',
     'ID=zorin\nID_LIKE="ubuntu debian"\nUBUNTU_CODENAME=questing\n',
     'ID=mystery\nVERSION_ID="1"\n',
     'ID=hybrid\nID_LIKE="ubuntu fedora"\nUBUNTU_CODENAME=noble\nPLATFORM_ID=platform:f44\n'

--- a/packaging/installer/installer.test.mjs
+++ b/packaging/installer/installer.test.mjs
@@ -331,9 +331,9 @@ const derivatives = [
     'ID=pop\nID_LIKE="ubuntu debian"\nVERSION_ID="24.04"\nUBUNTU_CODENAME=noble\n'
   ],
   [
-    'neon',
+    'zorin resolute',
     'Ubuntu 26.04',
-    'ID=neon\nID_LIKE="ubuntu debian"\nVERSION_ID="26.04"\nUBUNTU_CODENAME=resolute\n'
+    'ID=zorin\nID_LIKE="ubuntu debian"\nVERSION_ID="19"\nUBUNTU_CODENAME=resolute\n'
   ],
   [
     'devuan',
@@ -347,11 +347,13 @@ const derivatives = [
   ]
 ];
 
-for (const [id, base, osRelease] of derivatives) {
-  test(`detects supported ${id} derivative`, () => {
+for (const [name, base, osRelease] of derivatives) {
+  test(`detects supported ${name} derivative`, () => {
     const fixture = makeFixture({ osRelease });
     const result = fixture.run();
     assert.equal(result.status, 0, result.stdout + result.stderr);
+    const id = /^ID=([a-z0-9._+-]+)$/m.exec(osRelease)?.[1];
+    assert.ok(id, 'derivative fixture must contain a literal unquoted ID');
     assert.match(result.stdout, new RegExp(`${id} → ${base.replace('.', '\\.')} family`));
     assert.match(result.stdout, /compatible-family, not release-tested directly/);
     fixture.cleanup();
@@ -387,7 +389,8 @@ test('refuses malformed, duplicate, unsupported, and conflicting platform data',
     'ID="$(touch /tmp/no)"\nVERSION_ID="24.04"\n',
     'ID=ubuntu\nVERSION_ID="26.04"\nVERSION_CODENAME=questing\n',
     'ID=ubuntu\nVERSION_ID="26.04"\n',
-    'ID=zorin\nID_LIKE="ubuntu debian"\nUBUNTU_CODENAME=questing\n',
+    'ID=zorin\nID_LIKE="ubuntu debian"\nVERSION_ID="19"\nUBUNTU_CODENAME=questing\n',
+    'ID=zorin\nID_LIKE="ubuntu debian"\nVERSION_ID="19"\n',
     'ID=mystery\nVERSION_ID="1"\n',
     'ID=hybrid\nID_LIKE="ubuntu fedora"\nUBUNTU_CODENAME=noble\nPLATFORM_ID=platform:f44\n'
   ];

--- a/packaging/release/release-contract.test.mjs
+++ b/packaging/release/release-contract.test.mjs
@@ -165,17 +165,17 @@ test('documentation exposes release, review, integrity, manual, and source insta
   );
   assert.match(readme, /curl -fLO .*releases\/latest\/download\/install\.sh/);
   assert.match(readme, /less install\.sh\nbash install\.sh/);
-  assert.match(readme, /releases\/download\/v0\.9\.5\/\{install\.sh,SHA256SUMS\}/);
+  assert.match(readme, /releases\/download\/v0\.9\.6\/\{install\.sh,SHA256SUMS\}/);
   assert.match(
     readme,
-    /sudo apt install \.\/fangd_0\.9\.5-1_amd64\.deb \.\/Fang_0\.9\.5_amd64\.deb/
+    /sudo apt install \.\/fangd_0\.9\.6-1_amd64\.deb \.\/Fang_0\.9\.6_amd64\.deb/
   );
   assert.match(
     readme,
-    /sudo dnf install \.\/fangd-0\.9\.5-1\.x86_64\.rpm \.\/fang-0\.9\.5-1\.x86_64\.rpm/
+    /sudo dnf install \.\/fangd-0\.9\.6-1\.x86_64\.rpm \.\/fang-0\.9\.6-1\.x86_64\.rpm/
   );
   assert.match(readme, /sha256sum --check .*install\.sh/);
-  assert.match(readme, /^- Ubuntu 22\.04 and 24\.04$/m);
+  assert.match(readme, /^- Ubuntu 22\.04, 24\.04, and 26\.04$/m);
   assert.match(readme, /^- Debian 12 and 13$/m);
   assert.match(readme, /^- Fedora 43 and 44$/m);
   assert.match(readme, /do not add `sudo`/);

--- a/packaging/release/release-contract.test.mjs
+++ b/packaging/release/release-contract.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 import {
@@ -11,6 +12,30 @@ import {
   stageRelease,
   validateManifest
 } from './release-contract.mjs';
+
+const repositoryRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+const sourceInstaller = path.join(repositoryRoot, 'packaging/install-from-source.sh');
+
+function runSourceFamilyGuard(osRelease) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fang-source-installer-test-'));
+  const osReleasePath = path.join(fixtureRoot, 'os-release');
+  fs.writeFileSync(osReleasePath, osRelease);
+  try {
+    return spawnSync(
+      'bash',
+      [
+        '-c',
+        'source "$1"; source_installer_require_debian_family "$2"',
+        'fang-source-installer-test',
+        sourceInstaller,
+        osReleasePath
+      ],
+      { encoding: 'utf8' }
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true });
+  }
+}
 
 test('0.9.4 owns six exact assets and five checksum entries', () => {
   assert.deepEqual(releaseNames('0.9.4'), [
@@ -144,12 +169,36 @@ test('stageRelease rejects package metadata mismatches before staging', () => {
   fs.rmSync(root, { recursive: true });
 });
 
+test('source installer accepts valid direct and derived Debian-family os-release quoting', () => {
+  for (const osRelease of [
+    "ID='ubuntu'\n",
+    'ID="debian"\n',
+    "ID='zorin'\nID_LIKE='ubuntu debian'\n"
+  ]) {
+    const result = runSourceFamilyGuard(osRelease);
+    assert.equal(result.status, 0, osRelease + result.stdout + result.stderr);
+  }
+});
+
+test('source installer rejects malformed, duplicate, and unsupported family data', () => {
+  const marker = path.join(os.tmpdir(), `fang-source-installer-injection-${process.pid}`);
+  fs.rmSync(marker, { force: true });
+  for (const osRelease of [
+    'ID="ubuntu\n',
+    'ID=ubuntu\nID=debian\n',
+    'ID=notubuntu\n',
+    `ID="$(touch ${marker})"\n`
+  ]) {
+    const result = runSourceFamilyGuard(osRelease);
+    assert.notEqual(result.status, 0, osRelease);
+  }
+  assert.equal(fs.existsSync(marker), false);
+});
+
 test('documentation exposes release, review, integrity, manual, and source install paths', () => {
-  const repositoryRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
   const readme = fs.readFileSync(path.join(repositoryRoot, 'README.md'), 'utf8');
   const contributing = fs.readFileSync(path.join(repositoryRoot, 'CONTRIBUTING.md'), 'utf8');
   const hardware = fs.readFileSync(path.join(repositoryRoot, 'HARDWARE_TESTING.md'), 'utf8');
-  const sourceInstaller = path.join(repositoryRoot, 'packaging/install-from-source.sh');
 
   assert.equal(fs.existsSync(path.join(repositoryRoot, 'packaging/install.sh')), false);
   assert.ok(fs.statSync(sourceInstaller).mode & 0o111);

--- a/packaging/rpm/fang.spec
+++ b/packaging/rpm/fang.spec
@@ -2,7 +2,7 @@
 %global fangd_upper 0.10.0
 
 Name: fang
-Version: 0.9.5
+Version: 0.9.6
 Release: 1
 Summary: Razer Blade control center for Linux
 License: GPL-2.0-only

--- a/packaging/rpm/fangd.spec
+++ b/packaging/rpm/fangd.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: fangd
-Version: 0.9.5
+Version: 0.9.6
 Release: 1
 Summary: Privileged hardware-control daemon for Fang
 License: GPL-2.0-only


### PR DESCRIPTION
## Summary

- accept Ubuntu 26.04 LTS (resolute) in the release installer for direct Ubuntu installs and compatible-family derivatives
- validate the unchanged DEB pair on Ubuntu 26.04 in both CI and release workflow matrices while retaining the Ubuntu 22.04 build runner and glibc floor
- guard the Debian/Ubuntu-only source installer with strict source-free os-release parsing
- prepare and document Fang v0.9.6 across Rust, npm, Tauri, packaging, installer, and changelog metadata

## Compatibility

Ubuntu 26.04 still provides the required WebKitGTK 4.1, GTK 3, and Ayatana AppIndicator libraries. The DEB build jobs remain on Ubuntu 22.04 so released artifacts retain libc6 >= 2.35 compatibility with Ubuntu 22.04 and Debian 12.

## Verification

- Fang version synchronization: 0.9.6
- installer, release, publication, DEB, RPM, changelog, and version contract suites
- ShellCheck and Bash syntax checks
- Rust workspace format, Clippy, and 66 tests
- Tauri shell format, Clippy, and 10 tests
- frontend tests and production build
- Fedora 44 early-rejection check for the source installer
- real Ubuntu 26.04 DEB lifecycle validation recorded in the implementation handoff
- independent code review, including a focused re-review after fixes

## Release boundary

This PR prepares v0.9.6 but does not create a tag or publish a release. Release publication remains a separate action after CI is green.