### PR TITLE
Rebrand the GitHub project as VFang

### DIFF
--- a/.github/ISSUE_TEMPLATE/model-support.yml
+++ b/.github/ISSUE_TEMPLATE/model-support.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: SELinux status and denials
       description: "Fedora: include `getenforce` and any relevant `ausearch -m AVC -ts recent` lines"
-      placeholder: "Enforcing · no Fang-related AVC denials"
+      placeholder: "Enforcing · no VFang-related AVC denials"
   - type: textarea
     id: journal
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Fang are documented here. The format is based on
+All notable changes to VFang are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 [Semantic Versioning](https://semver.org/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,21 +355,21 @@ All notable changes to Fang are documented here. The format is based on
 - Privileged `fangd` daemon + unprivileged Tauri/Svelte app over a Unix socket;
   settings persist and re-apply after reboot and suspend/resume.
 
-[0.9.6]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.6
-[0.9.5]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.5
-[0.9.4]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.4
-[0.9.3]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.3
-[0.9.2]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.2
-[0.9.1]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.1
-[0.9.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.0
-[0.8.2]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.8.2
-[0.8.1]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.8.1
-[0.8.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.8.0
-[0.7.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.7.0
-[0.6.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.6.0
-[0.5.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.5.0
-[0.4.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.4.0
-[0.3.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.3.0
-[0.2.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.2.0
-[0.1.1]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.1.1
-[0.1.0]: https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.1.0
+[0.9.6]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.6
+[0.9.5]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.5
+[0.9.4]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.4
+[0.9.3]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.3
+[0.9.2]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.2
+[0.9.1]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.1
+[0.9.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0
+[0.8.2]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.8.2
+[0.8.1]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.8.1
+[0.8.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.8.0
+[0.7.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.7.0
+[0.6.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.6.0
+[0.5.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.5.0
+[0.4.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.4.0
+[0.3.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.3.0
+[0.2.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.2.0
+[0.1.1]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.1.1
+[0.1.0]: https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Fang
+# Contributing to VFang
 
 ## Development setup — no Razer hardware needed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["app/src-tauri"]
 version = "0.9.6"
 edition = "2021"
 license = "GPL-2.0"
-repository = "https://github.com/bladeandsoulx/fang-razer-linux"
+repository = "https://github.com/bladeandsoulx/vfang-razer-linux"
 authors = ["Solomon Morse <bladeandsoulx@protonmail.com>"]
 
 [workspace.dependencies]

--- a/HARDWARE_TESTING.md
+++ b/HARDWARE_TESTING.md
@@ -1,6 +1,6 @@
 # First run on real hardware (Razer Blade, Ubuntu or Fedora)
 
-Fang's EC packet layer is byte-verified against razer-laptop-control, but
+VFang's EC packet layer is byte-verified against razer-laptop-control, but
 this checklist is for the first boot on a physical Blade. Work through it in
 order; each step has a rollback.
 
@@ -14,7 +14,7 @@ echo "${XDG_SESSION_TYPE:-?}"   # record Wayland or X11
 getenforce 2>/dev/null || true  # Fedora: record enforcing/permissive/disabled
 ```
 
-Fang recognizes the PIDs in `crates/fang-protocol/src/models.rs`. An unknown
+VFang recognizes the PIDs in `crates/fang-protocol/src/models.rs`. An unknown
 Razer PID is monitor-only by default, even when it exposes a vendor HID usage
 page. Add the PID and verified limits to the model table before treating it as
 supported. For controlled bring-up only, explicitly approve that exact PID:
@@ -76,7 +76,7 @@ parked at idle is normal).
 
 ## 4. Performance mode switch
 
-In the Fang app (or via socket): switch Balanced → Gaming. Under a CPU load
+In the **Fang** app (or via socket): switch Balanced → Gaming. Under a CPU load
 (`stress-ng --cpu 8` for a minute), Gaming should hold noticeably higher
 package power / clocks than Silent. Check `journalctl -u fangd` for EC
 errors after each switch — there should be none.
@@ -167,6 +167,6 @@ settings to firmware defaults. To remove everything:
 
 Open an issue with: model + year, distribution + version, desktop + Wayland/X11
 session, `lsusb -d 1532:` output, `journalctl -u fangd -b` snippet, and which
-steps passed or failed. On Fedora, also include `getenforce` and any Fang-related
+steps passed or failed. On Fedora, also include `getenforce` and any VFang-related
 `ausearch -m AVC -ts recent` denials. This is enough to distinguish packaging,
 SELinux, desktop-session, and hardware-profile failures.

--- a/HARDWARE_TESTING.md
+++ b/HARDWARE_TESTING.md
@@ -36,7 +36,7 @@ Use the release installer on a supported x86_64 distribution. Run it as your
 desktop user, not with `sudo`:
 
 ```sh
-curl -fsSL https://github.com/bladeandsoulx/fang-razer-linux/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/bladeandsoulx/vfang-razer-linux/releases/latest/download/install.sh | bash
 ```
 
 For an Ubuntu/Debian source build instead:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Fang — Razer Blade Control Center for Linux
+# VFang — Razer Blade Control Center for Linux
 
 [![CI](https://github.com/bladeandsoulx/fang-razer-linux/actions/workflows/ci.yml/badge.svg)](https://github.com/bladeandsoulx/fang-razer-linux/actions/workflows/ci.yml)
 [![License: GPL-2.0](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](LICENSE)
 
 **Control your Razer Blade without Windows.**
 
-Fang is a free, open-source Linux app for performance modes, fan curves,
+VFang is a free, open-source Linux app for performance modes, fan curves,
 battery charging, keyboard lighting, GPU switching, displays, and live
 temperatures.
+
+VFang currently preserves the installed **Fang** application entry, the `fang`
+and `fangd` commands and packages, and existing service, group, socket, and
+configuration identifiers for compatibility.
 
 ## Install — one command
 
@@ -23,26 +27,26 @@ curl -fsSL https://github.com/bladeandsoulx/fang-razer-linux/releases/latest/dow
 
 Run the command as your normal user—do not add `sudo`. Enter your password only
 when the installer asks. If it says group access was added, log out and back in
-once, then open Fang.
+once, then open **Fang**.
 
 The installer chooses the correct packages for your Linux system, checks them,
-installs the app and background service together, upgrades an existing Fang
+installs the app and background service together, upgrades an existing VFang
 installation safely, and refuses downgrades.
 
-## See Fang in action
+## See VFang in action
 
-![Fang live thermal dashboard for a Razer Blade laptop on Linux](docs/screenshots/dashboard.png)
+![VFang live thermal dashboard for a Razer Blade laptop on Linux](docs/screenshots/dashboard.png)
 
 | Custom fan curves with thermal protection | Performance modes and power automation |
 |---|---|
-| ![Fang custom Razer Blade fan curve editor on Linux](docs/screenshots/fan-curve.png) | ![Fang Razer Blade performance modes on Linux](docs/screenshots/performance.png) |
+| ![VFang custom Razer Blade fan curve editor on Linux](docs/screenshots/fan-curve.png) | ![VFang Razer Blade performance modes on Linux](docs/screenshots/performance.png) |
 | Keyboard, logo, and display lighting | GPU mode and refresh-rate controls |
-| ![Fang Razer Blade RGB and display controls on Linux](docs/screenshots/lighting.png) | ![Fang Razer Blade GPU switching and refresh-rate controls on Linux](docs/screenshots/gpu-display.png) |
+| ![VFang Razer Blade RGB and display controls on Linux](docs/screenshots/lighting.png) | ![VFang Razer Blade GPU switching and refresh-rate controls on Linux](docs/screenshots/gpu-display.png) |
 
-_These screenshots use Fang's built-in hardware simulator. The real app has the
+_These screenshots use VFang's built-in hardware simulator. The real app has the
 same interface._
 
-## What Fang can do
+## What VFang can do
 
 - 🎛️ **Performance modes:** Silent, Balanced, Gaming, and Custom CPU/GPU power.
 - 🌀 **Fan control:** Automatic, fixed RPM, or your own fan curve.
@@ -58,13 +62,13 @@ same interface._
 - 🔁 **Tray and autostart:** Quickly switch modes and restore settings after
   reboot or sleep.
 
-Fang focuses on **Razer Blade laptops**. It does not currently remap
+VFang focuses on **Razer Blade laptops**. It does not currently remap
 mice/keyboards or create macros, so it is not a complete Razer Synapse
 replacement for every Razer device.
 
 ## Will it work on my laptop?
 
-Fang recognizes **48 Razer Blade models from 2015–2025**. Each known model has
+VFang recognizes **48 Razer Blade models from 2015–2025**. Each known model has
 its own safe fan limits and feature list.
 
 Tested x86_64 Linux bases:
@@ -84,7 +88,7 @@ Unknown Razer product IDs are monitor-only by default. Check the
 
 ## Safety
 
-Fang controls the laptop's embedded controller directly, but hardware-changing
+VFang controls the laptop's embedded controller directly, but hardware-changing
 features have guardrails:
 
 - Fan speeds and curves are kept inside the limits for your model.
@@ -141,7 +145,7 @@ sudo systemctl enable --now fangd
 sudo usermod -aG fang "$USER"
 ```
 
-Log out and back in once after adding the group. To remove Fang, run
+Log out and back in once after adding the group. To remove VFang, run
 `sudo apt remove fang fangd` or `sudo dnf remove fang fangd`.
 
 </details>
@@ -155,14 +159,14 @@ cd fang-razer-linux
 sudo ./packaging/install-from-source.sh
 ```
 
-The script installs the build tools, builds and installs Fang, starts its
+The script installs the build tools, builds and installs VFang, starts its
 background service, and gives your user access.
 
 </details>
 
 ## Development
 
-You can develop Fang on any OS without Razer hardware.
+You can develop VFang on any OS without Razer hardware.
 
 ```bash
 # Terminal 1: run the daemon with simulated hardware
@@ -188,25 +192,25 @@ management.
 Real hardware control uses the protected `/run/fangd.sock` Unix socket. TCP is
 available only with simulated hardware on a numeric loopback address.
 
-## Support Fang
+## Support VFang
 
-Fang's in-app **Support** screen lists the creator's BTC, USDT, and Solana
+VFang's in-app **Support** screen lists the creator's BTC, USDT, and Solana
 donation addresses. USDT supports BNB Smart Chain (BEP20) and Ethereum (ERC20).
 
 ## Credits and license
 
-Fang is licensed under [GPL-2.0](LICENSE).
+VFang is licensed under [GPL-2.0](LICENSE).
 
 Much of its hardware knowledge—EC packets, the 48-model device table, battery
 limiting, and lighting commands—comes from
 [Razer-Control](https://github.com/Rintastic247/Razer-Control) by
 **Rintastic247** (GPL-2.0), the maintained continuation of
 [razer-laptop-control-no-dkms](https://github.com/Razer-Linux/razer-laptop-control-no-dkms).
-Fang also uses information from [OpenRazer](https://openrazer.github.io/).
-If Fang helps you, please consider
+VFang also uses information from [OpenRazer](https://openrazer.github.io/).
+If VFang helps you, please consider
 [supporting the Razer-Control author](https://www.paypal.com/donate/?hosted_button_id=H4SCC24R8KS4A).
 
 Assisted-by: OpenAI GPT-5.6 via Codex and Claude Fable 5 via CLI.
 
-Fang is not affiliated with or endorsed by Razer Inc. “Razer” and “Synapse”
+VFang is not affiliated with or endorsed by Razer Inc. “Razer” and “Synapse”
 are trademarks of Razer Inc.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VFang — Razer Blade Control Center for Linux
 
-[![CI](https://github.com/bladeandsoulx/fang-razer-linux/actions/workflows/ci.yml/badge.svg)](https://github.com/bladeandsoulx/fang-razer-linux/actions/workflows/ci.yml)
+[![CI](https://github.com/bladeandsoulx/vfang-razer-linux/actions/workflows/ci.yml/badge.svg)](https://github.com/bladeandsoulx/vfang-razer-linux/actions/workflows/ci.yml)
 [![License: GPL-2.0](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](LICENSE)
 
 **Control your Razer Blade without Windows.**
@@ -20,7 +20,7 @@ configuration identifiers for compatibility.
 > Open **Terminal**, paste this one line, and press **Enter**:
 
 ```bash
-curl -fsSL https://github.com/bladeandsoulx/fang-razer-linux/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/bladeandsoulx/vfang-razer-linux/releases/latest/download/install.sh | bash
 ```
 
 **That is it.** When installation finishes, open **Fang** from your app menu.
@@ -107,7 +107,7 @@ layer.
 <summary><strong>Check the installer before running it</strong></summary>
 
 ```bash
-curl -fLO https://github.com/bladeandsoulx/fang-razer-linux/releases/latest/download/install.sh
+curl -fLO https://github.com/bladeandsoulx/vfang-razer-linux/releases/latest/download/install.sh
 less install.sh
 bash install.sh
 ```
@@ -118,7 +118,7 @@ For an extra integrity check, download the installer and checksum manifest from
 the pinned v0.9.6 release:
 
 ```bash
-curl -fLO 'https://github.com/bladeandsoulx/fang-razer-linux/releases/download/v0.9.6/{install.sh,SHA256SUMS}'
+curl -fLO 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/download/v0.9.6/{install.sh,SHA256SUMS}'
 grep '  install.sh$' SHA256SUMS > install.sh.sha256
 sha256sum --check install.sh.sha256
 ```
@@ -154,8 +154,8 @@ Log out and back in once after adding the group. To remove VFang, run
 <summary><strong>Build from source on Ubuntu or Debian</strong></summary>
 
 ```bash
-git clone https://github.com/bladeandsoulx/fang-razer-linux
-cd fang-razer-linux
+git clone https://github.com/bladeandsoulx/vfang-razer-linux
+cd vfang-razer-linux
 sudo ./packaging/install-from-source.sh
 ```
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ description = "Fang — Synapse-style control center for Razer Blade laptops on 
 version = "0.9.6"
 edition = "2021"
 license = "GPL-2.0"
-repository = "https://github.com/bladeandsoulx/fang-razer-linux"
+repository = "https://github.com/bladeandsoulx/vfang-razer-linux"
 authors = ["Solomon Morse <bladeandsoulx@protonmail.com>"]
 
 # Standalone: not a member of the repo-root cargo workspace.

--- a/app/src/lib/updater.js
+++ b/app/src/lib/updater.js
@@ -1,6 +1,6 @@
-const REPOSITORY = 'https://github.com/bladeandsoulx/fang-razer-linux';
+const REPOSITORY = 'https://github.com/bladeandsoulx/vfang-razer-linux';
 const LATEST_RELEASE_API =
-  'https://api.github.com/repos/bladeandsoulx/fang-razer-linux/releases/latest';
+  'https://api.github.com/repos/bladeandsoulx/vfang-razer-linux/releases/latest';
 
 function parseVersion(value) {
   const match = String(value)
@@ -30,7 +30,7 @@ function trustedReleaseUrl(value) {
     const url = new URL(value);
     if (
       url.origin === 'https://github.com' &&
-      url.pathname.startsWith('/bladeandsoulx/fang-razer-linux/releases/')
+      url.pathname.startsWith('/bladeandsoulx/vfang-razer-linux/releases/')
     ) {
       return url.href;
     }

--- a/app/src/lib/updater.test.js
+++ b/app/src/lib/updater.test.js
@@ -16,7 +16,7 @@ test('returns a newer published GitHub release', async () => {
     async json() {
       return {
         tag_name: 'v0.9.0',
-        html_url: 'https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.0'
+        html_url: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
       };
     }
   });
@@ -25,7 +25,7 @@ test('returns a newer published GitHub release', async () => {
     available: true,
     installedVersion: '0.8.2',
     latestVersion: '0.9.0',
-    releaseUrl: 'https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.0'
+    releaseUrl: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
   });
 });
 

--- a/app/src/lib/updater.test.js
+++ b/app/src/lib/updater.test.js
@@ -9,24 +9,54 @@ test('compares semantic versions numerically', () => {
   assert.equal(isNewerVersion('v1.0.0', '0.8.2-sim'), true);
 });
 
-test('returns a newer published GitHub release', async () => {
+test('requests and returns a newer published VFang release', async () => {
+  let request;
+  const fetchImpl = async (url, options) => {
+    request = { url, options };
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          tag_name: 'v0.9.0',
+          html_url: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
+        };
+      }
+    };
+  };
+
+  const update = await checkForUpdate('0.8.2', fetchImpl);
+
+  assert.deepEqual(request, {
+    url: 'https://api.github.com/repos/bladeandsoulx/vfang-razer-linux/releases/latest',
+    options: {
+      cache: 'no-store',
+      headers: { Accept: 'application/vnd.github+json' }
+    }
+  });
+  assert.deepEqual(update, {
+    available: true,
+    installedVersion: '0.8.2',
+    latestVersion: '0.9.0',
+    releaseUrl: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
+  });
+});
+
+test('does not trust legacy Fang repository release links', async () => {
   const fetchImpl = async () => ({
     ok: true,
     status: 200,
     async json() {
       return {
         tag_name: 'v0.9.0',
-        html_url: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
+        html_url: 'https://github.com/bladeandsoulx/fang-razer-linux/releases/tag/v0.9.0'
       };
     }
   });
 
-  assert.deepEqual(await checkForUpdate('0.8.2', fetchImpl), {
-    available: true,
-    installedVersion: '0.8.2',
-    latestVersion: '0.9.0',
-    releaseUrl: 'https://github.com/bladeandsoulx/vfang-razer-linux/releases/tag/v0.9.0'
-  });
+  const update = await checkForUpdate('0.8.2', fetchImpl);
+
+  assert.equal(update.releaseUrl, 'https://github.com/bladeandsoulx/vfang-razer-linux/releases');
 });
 
 test('rejects failed and malformed release responses', async () => {

--- a/app/src/screens/Support.svelte
+++ b/app/src/screens/Support.svelte
@@ -108,7 +108,7 @@
       <button
         type="button"
         class="project-link"
-        on:click={() => openExternal('https://github.com/bladeandsoulx/fang-razer-linux')}
+        on:click={() => openExternal('https://github.com/bladeandsoulx/vfang-razer-linux')}
       >
         View the open-source project <span aria-hidden="true">↗</span>
       </button>

--- a/docs/superpowers/specs/2026-07-30-vfang-github-rebrand-design.md
+++ b/docs/superpowers/specs/2026-07-30-vfang-github-rebrand-design.md
@@ -95,8 +95,9 @@ modified. The existing immutable-release policy remains enabled.
 
 1. Create an isolated rebrand branch from the current `origin/main`, keeping the
    in-progress Fedora work separate.
-2. Add focused tests for the new public brand, canonical URL, and compatibility
-   allowlist.
+2. Add a focused behavior test for the updater's canonical release URL. Audit
+   public branding and the compatibility allowlist directly rather than adding
+   source-text tests for human prose.
 3. Update maintained tracked content and run the repository's complete
    verification suite.
 4. Commit and push the reviewed changes.

--- a/docs/superpowers/specs/2026-07-30-vfang-github-rebrand-design.md
+++ b/docs/superpowers/specs/2026-07-30-vfang-github-rebrand-design.md
@@ -1,0 +1,151 @@
+# VFang GitHub Rebrand
+
+**Date:** 2026-07-30
+
+## Goal
+
+Rename the public GitHub identity of the project from **Fang** to **VFang**
+without changing the identifiers used by installed systems or published release
+assets.
+
+The canonical repository becomes:
+
+`https://github.com/bladeandsoulx/vfang-razer-linux`
+
+## Scope
+
+The rebrand covers the maintained GitHub-facing surfaces:
+
+- repository name: `fang-razer-linux` → `vfang-razer-linux`;
+- repository About description and topics;
+- current README branding, image alternative text, support wording, and
+  canonical repository links;
+- the current contributing guide, hardware-testing guide, and GitHub issue
+  template;
+- canonical repository URLs in maintained metadata, workflows, installer
+  configuration, updater code, service documentation, release tooling, and
+  their tests;
+- published GitHub release titles, using `VFang` consistently.
+
+The README will contain a short compatibility note explaining that VFang still
+uses the existing installed identifiers. Instructions must use the real current
+command, package, application-entry, and asset names rather than pretending
+that those identifiers have already been migrated.
+
+## Compatibility Boundary
+
+This pass does **not** rename:
+
+- Rust crates, binaries, commands, or package names: `fang`, `fangd`;
+- the systemd service `fangd.service`;
+- the `fang` Unix group;
+- `/run/fangd.sock` or other filesystem/configuration paths;
+- environment variables such as `FANGD_ADDR`;
+- D-Bus, Tauri, desktop-file, bundle, or updater identifiers;
+- existing release tags, checksums, attestations, or immutable assets;
+- historical changelog prose, completed design specifications, or
+  implementation plans;
+- user-visible strings inside the installed desktop application, daemon, or
+  installer, except where a string is a canonical repository URL.
+
+`Fang`, `fang`, and `fangd` may therefore remain in the repository when they
+refer to a compatibility identifier, current installed behavior, an immutable
+artifact, or a historical record. The rebrand is not a blind
+case-insensitive replacement.
+
+## Tracked-Content Changes
+
+### Public documentation
+
+The README heading and project prose use `VFang`. Screenshot alternative text,
+support headings, credits, and the non-affiliation statement use the new brand.
+Install and removal examples retain the actual technical identifiers.
+
+`CONTRIBUTING.md`, `HARDWARE_TESTING.md`, and visible issue-template copy use
+`VFang` when referring to the current project. Historical release entries in
+`CHANGELOG.md` retain their original product wording, while their raw repository
+links may move to the new canonical URL.
+
+### Canonical URLs
+
+Every active reference to
+`github.com/bladeandsoulx/fang-razer-linux` is classified before editing:
+
+- maintained links and operational repository constants change to
+  `github.com/bladeandsoulx/vfang-razer-linux`;
+- old links embedded in historical design records remain unchanged;
+- installer, updater, publishing, CI, and contract tests change together with
+  the code they verify.
+
+The source-clone example changes both the URL and checkout directory to
+`vfang-razer-linux`.
+
+### GitHub metadata and releases
+
+The repository is renamed with GitHub's repository rename operation. The About
+description begins with `VFang`, and the `vfang` topic is added without removing
+the existing discoverability topics.
+
+Published release titles are normalized to `VFang`, including older releases.
+Release bodies are retained as historical records unless a canonical repository
+link must be corrected. Tags, assets, checksums, and attestations are never
+modified. The existing immutable-release policy remains enabled.
+
+## Execution Order
+
+1. Create an isolated rebrand branch from the current `origin/main`, keeping the
+   in-progress Fedora work separate.
+2. Add focused tests for the new public brand, canonical URL, and compatibility
+   allowlist.
+3. Update maintained tracked content and run the repository's complete
+   verification suite.
+4. Commit and push the reviewed changes.
+5. Rename the GitHub repository to `vfang-razer-linux`.
+6. Immediately update the local `origin` remote to the new canonical URL.
+7. Update the GitHub About description, topics, and release titles.
+8. Merge the verified tracked-content change to the default branch.
+9. Verify the new repository page, default-branch README, releases, Actions,
+   clone/fetch behavior, and the old repository redirect.
+
+The old repository slug must not be reused, because doing so would disable
+GitHub's redirect from the old location.
+
+## Failure Handling
+
+- If the requested repository slug is unavailable, stop before changing any
+  metadata and report the conflict.
+- If the repository rename succeeds but a later metadata update fails, keep the
+  new name, update `origin`, and retry only the failed idempotent metadata
+  operation.
+- If tracked-content tests fail, do not merge the branch or alter the live
+  repository name.
+- If a release-title update fails, do not touch its immutable assets; report the
+  exact tag and leave the remaining release data intact.
+- If a GitHub Action references this repository as a reusable external action,
+  update that reference before renaming because GitHub does not redirect action
+  calls. The current repository must be checked explicitly for this condition.
+
+## Verification
+
+Local verification must demonstrate:
+
+- all existing Rust, Node, installer, packaging, and release-contract tests
+  pass;
+- the version-synchronization check passes;
+- active canonical URLs use `vfang-razer-linux`;
+- `VFang` appears on the maintained public documentation surfaces;
+- compatibility identifiers still use their original exact spelling;
+- remaining `Fang` occurrences are confined to the documented compatibility or
+  historical allowlist;
+- no unrelated tracked files changed.
+
+Live GitHub verification must demonstrate:
+
+- `bladeandsoulx/vfang-razer-linux` is the canonical repository;
+- its About description and topics use VFang;
+- the default README presents VFang and its links resolve;
+- all published release titles use VFang;
+- immutable releases remain enabled and their assets/checksums are unchanged;
+- CI on the merged default branch is green;
+- the former repository URL redirects to the new repository;
+- the local clone fetches from the new `origin`.

--- a/install.sh
+++ b/install.sh
@@ -602,7 +602,7 @@ set -euo pipefail
 umask 077
 readonly VERSION='0.9.6'
 readonly RELEASE_TAG='v0.9.6'
-readonly REPOSITORY='bladeandsoulx/fang-razer-linux'
+readonly REPOSITORY='bladeandsoulx/vfang-razer-linux'
 readonly RELEASE_BASE="https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}"
 readonly DEB_FANG="Fang_${VERSION}_amd64.deb"
 readonly DEB_FANGD="fangd_${VERSION}-1_amd64.deb"

--- a/packaging/fangd.service
+++ b/packaging/fangd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Fang daemon — performance and fan control for Razer Blade laptops
-Documentation=https://github.com/bladeandsoulx/fang-razer-linux
+Documentation=https://github.com/bladeandsoulx/vfang-razer-linux
 
 [Service]
 Type=exec

--- a/packaging/release/publish.test.mjs
+++ b/packaging/release/publish.test.mjs
@@ -111,7 +111,7 @@ printf '{}\\n'
 
   const env = {
     PATH: `${bin}:/usr/bin:/bin`,
-    GITHUB_REPOSITORY: 'bladeandsoulx/fang-razer-linux',
+    GITHUB_REPOSITORY: 'bladeandsoulx/vfang-razer-linux',
     GITHUB_SHA: 'a'.repeat(40),
     GITHUB_TOKEN: 'contents-token',
     IMMUTABLE_RELEASES_TOKEN: 'administration-read-token',

--- a/packaging/release/release-contract.test.mjs
+++ b/packaging/release/release-contract.test.mjs
@@ -210,7 +210,7 @@ test('documentation exposes release, review, integrity, manual, and source insta
   assert.match(readme, /open \*\*Fang\*\* from your app menu/i);
   assert.match(
     readme,
-    /curl -fsSL https:\/\/github\.com\/bladeandsoulx\/fang-razer-linux\/releases\/latest\/download\/install\.sh \| bash/
+    /curl -fsSL https:\/\/github\.com\/bladeandsoulx\/vfang-razer-linux\/releases\/latest\/download\/install\.sh \| bash/
   );
   assert.match(readme, /curl -fLO .*releases\/latest\/download\/install\.sh/);
   assert.match(readme, /less install\.sh\nbash install\.sh/);

--- a/packaging/rpm/fang.spec
+++ b/packaging/rpm/fang.spec
@@ -6,7 +6,7 @@ Version: 0.9.6
 Release: 1
 Summary: Razer Blade control center for Linux
 License: GPL-2.0-only
-URL: https://github.com/bladeandsoulx/fang-razer-linux
+URL: https://github.com/bladeandsoulx/vfang-razer-linux
 Source0: fang
 Source1: fang.desktop
 Source2: LICENSE

--- a/packaging/rpm/fangd.spec
+++ b/packaging/rpm/fangd.spec
@@ -5,7 +5,7 @@ Version: 0.9.6
 Release: 1
 Summary: Privileged hardware-control daemon for Fang
 License: GPL-2.0-only
-URL: https://github.com/bladeandsoulx/fang-razer-linux
+URL: https://github.com/bladeandsoulx/vfang-razer-linux
 Source0: fangd
 Source1: fangd.service
 Source2: fang.sysusers


### PR DESCRIPTION
Rebrands maintained GitHub documentation and canonical repository URLs as VFang while preserving all installed fang/fangd identifiers and immutable release artifacts.